### PR TITLE
Show just Javadoc with Truffle API - no internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ your own Truffle language.
 
 ## Further information
 
-* [Truffle JavaDoc](http://lafo.ssw.jku.at/javadoc/truffle/all/)
+* [Truffle JavaDoc](http://lafo.ssw.uni-linz.ac.at/javadoc/truffle/latest/)
 * [Truffle on Github](http://github.com/graalvm/truffle)
 * [Graal on Github](http://github.com/graalvm/graal-core)
 * [Truffle Tutorials and Presentations](https://wiki.openjdk.java.net/display/Graal/Publications+and+Presentations)


### PR DESCRIPTION
We should use Javadoc from http://github.com/graalvm/truffle page as it points to Truffle API and doesn't include distracting details about Truffle internals.