### PR TITLE
Direct use of SL from Java via PolyglotEngine to make it easier to de…

### DIFF
--- a/src/test/java/com/oracle/truffle/sl/test/SLFactorialTest.java
+++ b/src/test/java/com/oracle/truffle/sl/test/SLFactorialTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.sl.test;
+
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.vm.PolyglotEngine;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SLFactorialTest {
+    private PolyglotEngine engine;
+    private PolyglotEngine.Value factorial;
+    
+    @Before
+    public void initEngine() throws Exception {
+        engine = PolyglotEngine.newBuilder().build();
+        engine.eval(
+                Source.fromText("function fac(n) {\n"
+                        + "  if (n <= 1) {\n"
+                        + "    return 1;\n"
+                        + "  }\n"
+                        + "  prev = fac(n - 1);\n"
+                        + "  return prev * n;\n"
+                        + "}\n", "factorial.sl").
+                        withMimeType("application/x-sl")
+        );
+        factorial = engine.findGlobalSymbol("fac");
+    }
+    
+    @After
+    public void dispose() {
+        engine.dispose();
+    }
+    
+    @Test
+    public void factorialOf5() throws Exception {
+        Number ret = factorial.execute(5).as(Number.class);
+        assertEquals(120, ret.intValue());
+    }
+
+    @Test
+    public void factorialOf3() throws Exception {
+        Number ret = factorial.execute(3).as(Number.class);
+        assertEquals(6, ret.intValue());
+    }
+
+    @Test
+    public void factorialOf1() throws Exception {
+        Number ret = factorial.execute(1).as(Number.class);
+        assertEquals(1, ret.intValue());
+    }
+}


### PR DESCRIPTION
…monstrate multilanguage debugging capabilities of the IDEs.

Place breakpoint into SLFactorialTest:77 and debug the file in the IDE (Ctrl-Shift-F6). Once the breakpoint is hit, step into (press F7) and if the "Truffle Debugging" plugin is in, the execution should stop in a simple language.