### PR TITLE
Use cutout key for the launcher option

### DIFF
--- a/launcher/src/main/java/com/oracle/truffle/sl/launcher/SLMain.java
+++ b/launcher/src/main/java/com/oracle/truffle/sl/launcher/SLMain.java
@@ -141,7 +141,7 @@ public final class SLMain {
         if (index >= 0) {
             group = group.substring(0, index);
         }
-        options.put(key, value);
+        options.put(group, value);
         return true;
     }
 


### PR DESCRIPTION
the `group` is never used in the launcher option.

```
String group = key;
if (index >= 0) {
    group = group.substring(0, index);
}
options.put(key, value);
```

Or can we simply remove the lines about`group`?