### PR TITLE
Migrate copy script to Python 3

### DIFF
--- a/copy_from_graal.py
+++ b/copy_from_graal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Since Simple Language is not developed on this repository, we need to periodically sync this repository with the developement one.
@@ -16,7 +16,7 @@ def fail(message):
     """ Print message to stderr and exit script
 
     """
-    print >> sys.stderr, message
+    print(message, file=sys.stderr)
     sys.exit(1)
 
 def clone(repo, path = ""):
@@ -79,11 +79,11 @@ def update_sl(revision):
         clone(GRAAL_REPO, GRAAL_DIR)
     checkout(GRAAL_DIR, revision)
     copy_sl()
-    print ""
-    print "NOTE: Update the version in sl, README.md and all pom.xml files!"
-    print "NOTE: Follow the instructions in README.md and make sure mvn package executes correctly!"
-    print "NOTE: Make sure project open correctly on the supported IDEs!"
-    print ""
+    print("")
+    print("NOTE: Update the version in sl, README.md and all pom.xml files!")
+    print("NOTE: Follow the instructions in README.md and make sure mvn package executes correctly!")
+    print("NOTE: Make sure project open correctly on the supported IDEs!")
+    print("")
 
 if __name__ == "__main__":
     if (len(sys.argv) != 2):


### PR DESCRIPTION
Done automatically with `2to3 -wn copy_from_graal.py`, then the shebang was updated manually. Further manual adjustments seem to be unnecessary: the script works, and I don’t see anything else that should be updated.

However, to ensure the shebang actually has an effect, also make the script executable.