### PR TITLE
Specialize `DivNode`s for constant-at-runtime divisors

### DIFF
--- a/language/src/main/java/com/oracle/truffle/sl/nodes/expression/SLDivNode.java
+++ b/language/src/main/java/com/oracle/truffle/sl/nodes/expression/SLDivNode.java
@@ -41,6 +41,7 @@
 package com.oracle.truffle.sl.nodes.expression;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.NodeInfo;
@@ -55,8 +56,24 @@ import com.oracle.truffle.sl.runtime.SLBigNumber;
  */
 @NodeInfo(shortName = "/")
 public abstract class SLDivNode extends SLBinaryNode {
+    
+    /*
+     * This specialization handles nodes that have a "constant-at-runtime" divisor.
+     * For constant divisiors, the JIT can perform strength reduction and turn
+     * the division into a set of multiplication/shifts by constants.
+     * This is especially profitable for divisions with constant-at-runtime divisors
+     * that are executed in a hot loop.
+     * The limit of 3 specializations is arbitrary, no effort has been spent to find
+     * a sweet spot, as this is just meant as an example use case for @Cached.
+     */
+    @Specialization(guards = {"right == cachedRight"}, limit = "3", 
+                    rewriteOn = ArithmeticException.class)
+    protected long divCached(long left, long right, 
+             @Cached("right") long cachedRight) throws ArithmeticException {
+        return div(left, cachedRight);
+    }
 
-    @Specialization(rewriteOn = ArithmeticException.class)
+    @Specialization(replaces = "divCached", rewriteOn = ArithmeticException.class)
     protected long div(long left, long right) throws ArithmeticException {
         long result = left / right;
         /*


### PR DESCRIPTION
With this change, that is really just meant as an example of an additional kind of use cases for `@Cached`, the following contrived example:

```
function main() {
  i = 0;
  j = 0;
  k = 1;
  while (j < 1000000000) {
    j = j + i/(100000000+k);
    i = i + 1;
    if (k == 1) {
      k = 3;
    } else {
      k = 1;
    }
  }
  return j;
}
```

runs on my machine in:
```
real    0m3.020s
user    0m2.241s
sys     0m0.107s
```
whereas before it took more than twice as long:
```
real    0m5.912s
user    0m5.175s
sys     0m0.082s
```

Incidentally, the resulting optimization capability (strength reduction of divisions with non-constant divisors) is not available in any AOT compiler (gcc, clang, icc).