### PR TITLE
Fixed disassemble of Truffle compiled methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
-    <graalvm.version>23.1.0</graalvm.version>
+    <graalvm.version>23.1.3</graalvm.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <launcherClass>org.graalvm.sl.launcher/com.oracle.truffle.sl.launcher.SLMain</launcherClass>

--- a/standalone/sl
+++ b/standalone/sl
@@ -55,7 +55,7 @@ if [ -d "$JAVA_HOME/lib/graalvm" ]; then
         -dump)
             JAVA_ARGS+=("-Dpolyglot.engine.AllowExperimentalOptions=true" "-Dgraal.PrintGraph=Network" "-Dgraal.Dump=Truffle:1" "-Dpolyglot.engine.BackgroundCompilation=false" "-Dpolyglot.engine.TraceCompilation=true" "-Dpolyglot.engine.TraceCompilationDetails=true") ;;
         -disassemble)
-            JAVA_ARGS+=("-Dpolyglot.engine.AllowExperimentalOptions=true" "-XX:CompileCommand=print,*.*" "-XX:CompileCommand=exclude,*OptimizedCallTarget.profiledPERoot" "-Dpolyglot.engine.BackgroundCompilation=false" "-Dpolyglot.engine.TraceCompilation=true" "-Dpolyglot.engine.TraceCompilationDetails=true") ;;
+            JAVA_ARGS+=("-Dpolyglot.engine.AllowExperimentalOptions=true" "-XX:CompileCommand=print,*OptimizedCallTarget.profiledPERoot" "-Dpolyglot.engine.BackgroundCompilation=false" "-Dpolyglot.engine.TraceCompilation=true" "-Dpolyglot.engine.TraceCompilationDetails=true") ;;
         -J*)
             opt=${opt:2}
             JAVA_ARGS+=("$opt") ;;

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -65,17 +65,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.1.2</version>
         <configuration>
-           <argLine>
-               -Dtck.values=java-host,sl 
-               -Dtck.language=sl
-            </argLine>
             <dependenciesToScan>
                 <dependency>org.graalvm.truffle:truffle-tck-tests</dependency>
             </dependenciesToScan>
-          <includes>
-            <include>**/*TestSuite.java</include>
-            <include>**/*Test.java</include>
-          </includes>
         </configuration>
       </plugin>
     </plugins>
@@ -91,7 +83,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <finalName>simplelanguage</finalName>
   </build>
     <dependencies>
         <dependency>
@@ -108,12 +99,6 @@
         <dependency>
             <groupId>org.graalvm.truffle</groupId>
             <artifactId>truffle-tck-tests</artifactId>
-            <version>${graalvm.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.truffle</groupId>
-            <artifactId>truffle-tck-common</artifactId>
             <version>${graalvm.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
1. Fixed disassemble of Truffle compiled methods.
2. Removed non needed TCK pom.xml configurations.

The above fixes are already in the [graal/truffle/external_repos/simplelanguage](https://github.com/oracle/graal/tree/master/truffle/external_repos/simplelanguage).

This pull request also updates graalvm to 23.1.3.